### PR TITLE
Reduction of the work for the docker cp stage for outputs

### DIFF
--- a/src/main/java/org/n52/gfz/riesgos/algorithm/BaseGfzRiesgosService.java
+++ b/src/main/java/org/n52/gfz/riesgos/algorithm/BaseGfzRiesgosService.java
@@ -948,21 +948,26 @@ public class BaseGfzRiesgosService
         private void readFromOutputFiles(
                 final IExecutionContext context) throws ExceptionReport {
 
-            final Set<String> requestedParameters = getSetWithRequestedOutputIds();
+            final Set<String> requestedParameters =
+                    getSetWithRequestedOutputIds();
             try {
                 for (final IOutputParameter outputValue : outputIdentifiers) {
-                    if (requestedParameters.contains(outputValue.getIdentifier())) {
+                    if (requestedParameters.contains(
+                            outputValue.getIdentifier())
+                    ) {
                         try {
                             final Optional<String> optionalPath =
-                                    outputValue.getPathToWriteToOrReadFromFile();
+                                outputValue.getPathToWriteToOrReadFromFile();
                             final Optional<IReadIDataFromFiles>
-                                    optionalFunctionToReadFromFiles =
-                                    outputValue.getFunctionToReadIDataFromFiles();
+                                optionalFunctionToReadFromFiles =
+                                outputValue.getFunctionToReadIDataFromFiles();
                             if (optionalPath.isPresent()
-                                    && optionalFunctionToReadFromFiles.isPresent()) {
+                                && optionalFunctionToReadFromFiles.isPresent()
+                            ) {
 
                                 final String path = optionalPath.get();
-                                final IReadIDataFromFiles functionToReadFromFiles =
+                                final IReadIDataFromFiles
+                                        functionToReadFromFiles =
                                         optionalFunctionToReadFromFiles.get();
                                 final DataWithRecreatorTuple readResult =
                                         functionToReadFromFiles.readFromFiles(

--- a/src/main/java/org/n52/gfz/riesgos/algorithm/BaseGfzRiesgosService.java
+++ b/src/main/java/org/n52/gfz/riesgos/algorithm/BaseGfzRiesgosService.java
@@ -17,6 +17,7 @@ package org.n52.gfz.riesgos.algorithm;
  */
 
 import net.opengis.wps.x100.ProcessDescriptionsDocument;
+import net.opengis.wps.x20.OutputDefinitionType;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.exception.ExceptionUtils;
 import org.n52.gfz.riesgos.cache.DataWithRecreatorTuple;
@@ -54,6 +55,9 @@ import org.n52.gfz.riesgos.processdescription.IProcessDescriptionGeneratorOutput
 import org.n52.gfz.riesgos.processdescription.impl.ProcessDescriptionGeneratorDataConfigImpl;
 import org.n52.gfz.riesgos.processdescription.impl.ProcessDescriptionGeneratorImpl;
 import org.n52.gfz.riesgos.util.Tuple;
+import org.n52.wps.commons.context.ExecutionContext;
+import org.n52.wps.commons.context.ExecutionContextFactory;
+import org.n52.wps.commons.context.OutputTypeWrapper;
 import org.n52.wps.io.data.IData;
 import org.n52.wps.server.AbstractSelfDescribingAlgorithm;
 import org.n52.wps.server.ExceptionReport;
@@ -64,9 +68,11 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -275,7 +281,11 @@ public class BaseGfzRiesgosService
             final Map<String, List<IData>> inputDataFromMethod)
             throws ExceptionReport {
 
-        final String hash = hasher.hash(configuration, inputDataFromMethod);
+        final Set<String> requestedParameters = getSetWithRequestedOutputIds();
+        final String hash = hasher.hash(
+                configuration,
+                inputDataFromMethod,
+                requestedParameters);
 
         logger.info("Cache-Hash: " + hash);
 
@@ -312,6 +322,26 @@ public class BaseGfzRiesgosService
                 Map.Entry::getKey,
                 entry -> entry.getValue().getFirst()
         ));
+    }
+
+    private Set<String> getSetWithRequestedOutputIds() {
+        final Set<String> requestedParameters = new HashSet<>();
+
+        final ExecutionContext wpsExecutionContext =
+                ExecutionContextFactory.getContext();
+        final OutputTypeWrapper outputTypeWrapper =
+                wpsExecutionContext.getOutputs();
+
+        if (outputTypeWrapper.isWPS100Execution()) {
+            outputTypeWrapper.getWps100OutputDefinitionTypes().stream().map(
+                    outputType -> outputType.getIdentifier().getStringValue()
+            ).forEach(requestedParameters::add);
+        } else {
+            outputTypeWrapper.getWps200OutputDefinitionTypes().stream().map(
+                    OutputDefinitionType::getId
+            ).forEach(requestedParameters::add);
+        }
+        return requestedParameters;
     }
 
     /**
@@ -918,42 +948,44 @@ public class BaseGfzRiesgosService
         private void readFromOutputFiles(
                 final IExecutionContext context) throws ExceptionReport {
 
+            final Set<String> requestedParameters = getSetWithRequestedOutputIds();
             try {
                 for (final IOutputParameter outputValue : outputIdentifiers) {
-                    try {
-                        final Optional<String> optionalPath =
-                                outputValue.getPathToWriteToOrReadFromFile();
-                        final Optional<IReadIDataFromFiles>
-                                optionalFunctionToReadFromFiles =
-                                outputValue.getFunctionToReadIDataFromFiles();
-                        if (optionalPath.isPresent()
-                            && optionalFunctionToReadFromFiles.isPresent()) {
+                    if (requestedParameters.contains(outputValue.getIdentifier())) {
+                        try {
+                            final Optional<String> optionalPath =
+                                    outputValue.getPathToWriteToOrReadFromFile();
+                            final Optional<IReadIDataFromFiles>
+                                    optionalFunctionToReadFromFiles =
+                                    outputValue.getFunctionToReadIDataFromFiles();
+                            if (optionalPath.isPresent()
+                                    && optionalFunctionToReadFromFiles.isPresent()) {
 
-                            final String path = optionalPath.get();
-                            final IReadIDataFromFiles functionToReadFromFiles =
-                                    optionalFunctionToReadFromFiles.get();
-                            final DataWithRecreatorTuple readResult =
-                                    functionToReadFromFiles.readFromFiles(
+                                final String path = optionalPath.get();
+                                final IReadIDataFromFiles functionToReadFromFiles =
+                                        optionalFunctionToReadFromFiles.get();
+                                final DataWithRecreatorTuple readResult =
+                                        functionToReadFromFiles.readFromFiles(
                                             context,
                                             configuration.getWorkingDirectory(),
                                             path);
-                            putIntoOutput(
-                                    outputValue,
-                                    readResult.getData(),
-                                    readResult.getRecreator());
-                        }
-                    } catch (final IOException
-                            | ConvertToIDataException exception) {
-                        if (outputValue.isOptional()) {
-                            logger.info("Can't read from output file.");
-                            logger.info("But since '"
-                                    + outputValue.getIdentifier()
-                                    + "' is optional, it can be ignored.");
-                        } else {
-                            throw exception;
+                                putIntoOutput(
+                                        outputValue,
+                                        readResult.getData(),
+                                        readResult.getRecreator());
+                            }
+                        } catch (final IOException
+                                | ConvertToIDataException exception) {
+                            if (outputValue.isOptional()) {
+                                logger.info("Can't read from output file.");
+                                logger.info("But since '"
+                                        + outputValue.getIdentifier()
+                                        + "' is optional, it can be ignored.");
+                            } else {
+                                throw exception;
+                            }
                         }
                     }
-
                 }
             } catch (final IOException ioException) {
                 logger.error("Files could not be read", ioException);

--- a/src/main/java/org/n52/gfz/riesgos/algorithm/BaseGfzRiesgosService.java
+++ b/src/main/java/org/n52/gfz/riesgos/algorithm/BaseGfzRiesgosService.java
@@ -324,6 +324,11 @@ public class BaseGfzRiesgosService
         ));
     }
 
+    /**
+     * This returns a set of the identifiers (as strinds) that the user
+     * requests.
+     * @return Set with output parameter identifiers.
+     */
     private Set<String> getSetWithRequestedOutputIds() {
         final Set<String> requestedParameters = new HashSet<>();
 

--- a/src/main/java/org/n52/gfz/riesgos/cache/hash/HasherImpl.java
+++ b/src/main/java/org/n52/gfz/riesgos/cache/hash/HasherImpl.java
@@ -40,6 +40,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 /**
  * Implementation of the hasher, that takes the input
@@ -89,18 +90,21 @@ public class HasherImpl implements IHasher {
      * Creates a hash from the configuration and the input data.
      * @param configuration configuration used for the process
      * @param inputData input data for the process
+     * @param requestedParameters output parameters that the user requested
      * @return hash for the overall input environment and the
      * output handling
      */
     @Override
     public String hash(
             final IConfiguration configuration,
-            final Map<String, List<IData>> inputData) {
+            final Map<String, List<IData>> inputData,
+            final Set<String> requestedParameters) {
 
         final CacheKey key = new CacheKey(
                 configuration,
                 imageIdLookup.lookUpImageId(configuration.getImageId()),
                 inputData,
+                requestedParameters,
                 imageIdLookup.getDockerVersion(),
                 wpsVersionHandler.getRepositoryVersion(),
                 wpsVersionHandler.getWpsVersion());
@@ -178,6 +182,10 @@ public class HasherImpl implements IHasher {
         private final List<IOutputParameter> outputParameters;
 
         /**
+         * A set with the output parameters that the user requested.
+         */
+        private final Set<String> requestedParameters;
+        /**
          * The version of docker.
          */
         private final String dockerVersion;
@@ -213,6 +221,8 @@ public class HasherImpl implements IHasher {
          * @param configuration configuration to use for caching
          * @param aImageId      real image id to use for running the code
          * @param inputData     input data to execute the code with
+         * @param aRequestedParameters set of output parameters that the user
+         *                             requested
          * @param aDockerVersion docker version of the docker daemon
          * @param aWpsVersion version of the wps server
          * @param aRepositoryVersion version of the repository
@@ -220,6 +230,7 @@ public class HasherImpl implements IHasher {
         CacheKey(final IConfiguration configuration,
                  final String aImageId,
                  final Map<String, List<IData>> inputData,
+                 final Set<String> aRequestedParameters,
                  final String aDockerVersion,
                  final String aWpsVersion,
                  final String aRepositoryVersion) {
@@ -243,6 +254,7 @@ public class HasherImpl implements IHasher {
 
             // just to now the handling of the output
             outputParameters = configuration.getOutputIdentifiers();
+            this.requestedParameters = aRequestedParameters;
 
             inputCacheKeyMap = new ArrayList<>();
 
@@ -311,6 +323,8 @@ public class HasherImpl implements IHasher {
                     && Objects.equals(stdoutHandler, cacheKey.stdoutHandler)
                     && Objects.equals(outputParameters,
                     cacheKey.outputParameters)
+                    && Objects.equals(requestedParameters,
+                    cacheKey.requestedParameters)
                     && Objects.equals(inputCacheKeyMap,
                     cacheKey.inputCacheKeyMap)
                     && Objects.equals(dockerVersion, cacheKey.dockerVersion)
@@ -336,6 +350,7 @@ public class HasherImpl implements IHasher {
                     stderrHandler,
                     stdoutHandler,
                     outputParameters,
+                    requestedParameters,
                     inputCacheKeyMap,
                     dockerVersion,
                     wpsVersion,

--- a/src/main/java/org/n52/gfz/riesgos/cache/hash/HasherSingleton.java
+++ b/src/main/java/org/n52/gfz/riesgos/cache/hash/HasherSingleton.java
@@ -23,6 +23,7 @@ import org.n52.wps.io.data.IData;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Singleton implementation of the hasher.
@@ -55,12 +56,14 @@ public enum HasherSingleton implements IHasher {
      * input data.
      * @param configuration configuration of the process
      * @param inputData input data for the query
+     * @param requestedParameters requested output parameters by the user
      * @return hash
      */
     @Override
     public String hash(
             final IConfiguration configuration,
-            final Map<String, List<IData>> inputData) {
-        return wrappedHasher.hash(configuration, inputData);
+            final Map<String, List<IData>> inputData,
+            final Set<String> requestedParameters) {
+        return wrappedHasher.hash(configuration, inputData, requestedParameters);
     }
 }

--- a/src/main/java/org/n52/gfz/riesgos/cache/hash/HasherSingleton.java
+++ b/src/main/java/org/n52/gfz/riesgos/cache/hash/HasherSingleton.java
@@ -64,6 +64,9 @@ public enum HasherSingleton implements IHasher {
             final IConfiguration configuration,
             final Map<String, List<IData>> inputData,
             final Set<String> requestedParameters) {
-        return wrappedHasher.hash(configuration, inputData, requestedParameters);
+        return wrappedHasher.hash(
+            configuration,
+            inputData,
+            requestedParameters);
     }
 }

--- a/src/main/java/org/n52/gfz/riesgos/cache/hash/IHasher.java
+++ b/src/main/java/org/n52/gfz/riesgos/cache/hash/IHasher.java
@@ -21,6 +21,7 @@ import org.n52.wps.io.data.IData;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * This is the interface for the computation of the
@@ -35,10 +36,12 @@ public interface IHasher {
      * Computes the hash for the configuration and the input data.
      * @param configuration configuration of the process that should be cached
      * @param inputData input data for the process
+     * @param requestedParameters the ids of the output that the user requested
      * @return hash (unique for the combination of configuration and input data)
      */
     String hash(
             IConfiguration configuration,
-            Map<String, List<IData>> inputData);
+            Map<String, List<IData>> inputData,
+            Set<String> requestedParameters);
 
 }

--- a/src/test/java/org/n52/gfz/riesgos/cache/hash/TestHasherImpl.java
+++ b/src/test/java/org/n52/gfz/riesgos/cache/hash/TestHasherImpl.java
@@ -23,8 +23,10 @@ import static org.junit.Assert.assertNotEquals;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.apache.xmlbeans.XmlException;
 import org.apache.xmlbeans.XmlObject;
@@ -82,8 +84,10 @@ public class TestHasherImpl {
 
         final IHasher hasher = new HasherImpl(new NoDockerImageIdLookup(), new NoWpsVersionHandler());
 
-        final String hash1 = hasher.hash(configuration1, inputData1);
-        final String hashSameAs1 = hasher.hash(configurationSameAs1, inputDataSameAs1);
+        final Set<String> emptySet = new HashSet<>(Collections.emptyList());
+
+        final String hash1 = hasher.hash(configuration1, inputData1, emptySet);
+        final String hashSameAs1 = hasher.hash(configurationSameAs1, inputDataSameAs1, emptySet);
 
         assertEquals("Both hashes are the same", hash1, hashSameAs1);
 
@@ -97,16 +101,20 @@ public class TestHasherImpl {
                         "times", false, null, null, null, null)
                 ).build();
 
-        final String hash2 = hasher.hash(configuration2, inputData1);
+        final String hash2 = hasher.hash(configuration2, inputData1, emptySet);
 
         assertNotEquals("The hashes are different", hash1, hash2);
 
         final Map<String, List<IData>> inputData2 = new HashMap<>();
         inputData2.put("times", Collections.singletonList(new LiteralIntBinding(4)));
 
-        final String hash3 = hasher.hash(configuration1, inputData2);
+        final String hash3 = hasher.hash(configuration1, inputData2, emptySet);
 
         assertNotEquals("The hashes are different", hash1, hash3);
+
+        final String hash1OtherSet = hasher.hash(configuration1, inputData1, new HashSet<>(Arrays.asList("parameter1")));
+
+        assertNotEquals("hash1 and hash1OhterSet are not equal", hash1, hash1OtherSet);
     }
 
     @Test
@@ -128,7 +136,7 @@ public class TestHasherImpl {
                                                     null))
                     .build();
 
-            final String hash1 = hasher.hash(conf1, exampleInputData);
+            final String hash1 = hasher.hash(conf1, exampleInputData, Collections.emptySet());
 
             final IConfiguration conf2 = new ConfigurationImpl.Builder("a", null, "b", "/tmp", Arrays.asList("ls"))
                     .withAddedInputIdentifier(
@@ -142,7 +150,7 @@ public class TestHasherImpl {
                                             "a.xml"))
                     .build();
 
-            final String hash2 = hasher.hash(conf2, exampleInputData);
+            final String hash2 = hasher.hash(conf2, exampleInputData, Collections.emptySet());
 
             assertNotEquals("Both should not be equal", hash1, hash2);
 
@@ -158,7 +166,7 @@ public class TestHasherImpl {
                                             "b.xml"))
                     .build();
 
-            final String hash3 = hasher.hash(conf3, exampleInputData);
+            final String hash3 = hasher.hash(conf3, exampleInputData, Collections.emptySet());
 
             assertNotEquals("Both should not be equal", hash2, hash3);
 
@@ -174,7 +182,7 @@ public class TestHasherImpl {
                                             "a.xml"))
                     .build();
 
-            final String hash4 = hasher.hash(conf4, exampleInputData);
+            final String hash4 = hasher.hash(conf4, exampleInputData, Collections.emptySet());
 
             assertNotEquals("Both should not be equal", hash2, hash4);
 
@@ -190,7 +198,7 @@ public class TestHasherImpl {
                                             "a.xml"))
                     .build();
 
-            final String hash5 = hasher.hash(conf5, exampleInputData);
+            final String hash5 = hasher.hash(conf5, exampleInputData, Collections.emptySet());
 
             assertNotEquals("Both should not be equal", hash2, hash5);
 
@@ -206,7 +214,7 @@ public class TestHasherImpl {
                                             "a.xml"))
                     .build();
 
-            final String hash6 = hasher.hash(conf6, exampleInputData);
+            final String hash6 = hasher.hash(conf6, exampleInputData, Collections.emptySet());
 
             assertEquals("Both should be equal", hash6, hash5);
         } catch (final XmlException xmlException) {
@@ -324,7 +332,7 @@ public class TestHasherImpl {
                 new NoWpsVersionHandler()
             );
 
-            final String hash = hasher.hash(shakygroundConfig, inputData1);
+            final String hash = hasher.hash(shakygroundConfig, inputData1, Collections.emptySet());
 
             final String dummyXml2 = "<eventParameters publicID=\"quakeml:"
                 + "quakeledger/0\" xmlns="
@@ -412,7 +420,7 @@ public class TestHasherImpl {
                 )
             );
 
-            final String hash2 = hasher.hash(shakygroundConfig, inputData2);
+            final String hash2 = hasher.hash(shakygroundConfig, inputData2, Collections.emptySet());
 
             assertNotEquals("The hashes must be different", hash, hash2);
 
@@ -500,7 +508,7 @@ public class TestHasherImpl {
                 )
             );
 
-            final String hash3 = hasher.hash(shakygroundConfig, inputData3);
+            final String hash3 = hasher.hash(shakygroundConfig, inputData3, Collections.emptySet());
 
             assertEquals("hash and hash3 must be equal", hash, hash3);
 
@@ -511,7 +519,8 @@ public class TestHasherImpl {
 
             final String hash4 = otherHasher.hash(
                 shakygroundConfig,
-                inputData3
+                inputData3,
+                Collections.emptySet()
             );
 
             assertEquals(
@@ -543,7 +552,7 @@ public class TestHasherImpl {
                         )
                 ).build();
 
-            final String hash5 = otherHasher.hash(shakygroundConf2, inputData3);
+            final String hash5 = otherHasher.hash(shakygroundConf2, inputData3, Collections.emptySet());
 
             assertEquals(
                 "Hashes for recreated configurations (the same ones) "
@@ -586,8 +595,8 @@ public class TestHasherImpl {
 
         final IHasher hasher = new HasherImpl(new NoDockerImageIdLookup(), new NoWpsVersionHandler());
 
-        final String hash1 = hasher.hash(configuration1, inputData);
-        final String hash2 = hasher.hash(configuration2, inputData);
+        final String hash1 = hasher.hash(configuration1, inputData, Collections.emptySet());
+        final String hash2 = hasher.hash(configuration2, inputData, Collections.emptySet());
 
         assertNotEquals("Both hashes are different", hash1, hash2);
 
@@ -603,7 +612,7 @@ public class TestHasherImpl {
                 .withAddedOutputIdentifier(OutputParameterFactory.INSTANCE.createStdoutString("stdout", false, null))
                 .build();
 
-        final String hash3 = hasher.hash(configuration3, inputData);
+        final String hash3 = hasher.hash(configuration3, inputData, Collections.emptySet());
 
         assertEquals("2 and 3 are equal", hash2, hash3);
 
@@ -618,7 +627,7 @@ public class TestHasherImpl {
                 .withAddedOutputIdentifier(OutputParameterFactory.INSTANCE.createFileOutGeneric("stdout", false, null, null, "a.txt"))
                 .build();
 
-        final String hash4 = hasher.hash(configuration4, inputData);
+        final String hash4 = hasher.hash(configuration4, inputData, Collections.emptySet());
 
         assertNotEquals("the hashes are different", hash2, hash4);
     }
@@ -669,8 +678,8 @@ public class TestHasherImpl {
 
         final IHasher hasher = new HasherImpl(new NoDockerImageIdLookup(), new NoWpsVersionHandler());
 
-        final String hash1 = hasher.hash(conf1, inputValues);
-        final String hash2 = hasher.hash(conf2, inputValues);
+        final String hash1 = hasher.hash(conf1, inputValues, Collections.emptySet());
+        final String hash2 = hasher.hash(conf2, inputValues, Collections.emptySet());
 
         assertNotEquals("The ordering is different -> not equals", hash1, hash2);
     }

--- a/src/test/java/org/n52/gfz/riesgos/cache/impl/TestCacheImpl.java
+++ b/src/test/java/org/n52/gfz/riesgos/cache/impl/TestCacheImpl.java
@@ -81,7 +81,7 @@ public class TestCacheImpl {
         final Map<String, List<IData>> inputData = new HashMap<>();
         inputData.put(configuration.getInputIdentifiers().get(0).getIdentifier(), Collections.singletonList(literalIntInput));
 
-        final String hash = hasher.hash(configuration, inputData);
+        final String hash = hasher.hash(configuration, inputData, Collections.emptySet());
 
         final Optional<Map<String, IDataRecreator>> optionalCacheResult = cache.getCachedResult(hash);
 
@@ -126,7 +126,7 @@ public class TestCacheImpl {
         final Map<String, List<IData>> inputData2 = new HashMap<>();
         inputData2.put(configuration2.getInputIdentifiers().get(0).getIdentifier(), Collections.singletonList(literalIntInput2));
 
-        final String hash2 = hasher.hash(configuration2, inputData2);
+        final String hash2 = hasher.hash(configuration2, inputData2, Collections.emptySet());
         final Optional<Map<String, IDataRecreator>> cachedResult2 = cache.getCachedResult(hash2);
 
         // I think it is a problem regarding to identities and equality
@@ -146,7 +146,7 @@ public class TestCacheImpl {
         final Map<String, List<IData>> inputData = new HashMap<>();
         inputData.put(configuration.getInputIdentifiers().get(0).getIdentifier(), Collections.singletonList(bbox));
 
-        final String hash = hasher.hash(configuration, inputData);
+        final String hash = hasher.hash(configuration, inputData, Collections.emptySet());
         final Optional<Map<String, IDataRecreator>> optionalCacheResult = cache.getCachedResult(hash);
 
         assertFalse("There is no data at the beginning", optionalCacheResult.isPresent());
@@ -185,7 +185,7 @@ public class TestCacheImpl {
         final Map<String, List<IData>> inputData2 = new HashMap<>();
         inputData2.put(configuration2.getInputIdentifiers().get(0).getIdentifier(), Collections.singletonList(bbox2));
 
-        final String hash2 = hasher.hash(configuration2, inputData2);
+        final String hash2 = hasher.hash(configuration2, inputData2, Collections.emptySet());
         final Optional<Map<String, IDataRecreator>> cachedResult2 = cache.getCachedResult(hash2);
 
         // I think it is a problem regarding to identities and equality
@@ -206,7 +206,7 @@ public class TestCacheImpl {
             final Map<String, List<IData>> inputData = new HashMap<>();
             inputData.put(configuration.getInputIdentifiers().get(0).getIdentifier(), Collections.singletonList(xml));
 
-            final String hash = hasher.hash(configuration, inputData);
+            final String hash = hasher.hash(configuration, inputData, Collections.emptySet());
             final Optional<Map<String, IDataRecreator>> optionalCacheResult = cache.getCachedResult(hash);
 
             assertFalse("There is no data at the beginning", optionalCacheResult.isPresent());
@@ -246,7 +246,7 @@ public class TestCacheImpl {
             final Map<String, List<IData>> inputData2 = new HashMap<>();
             inputData2.put(configuration2.getInputIdentifiers().get(0).getIdentifier(), Collections.singletonList(xml2));
 
-            final String hash2 = hasher.hash(configuration2, inputData2);
+            final String hash2 = hasher.hash(configuration2, inputData2, Collections.emptySet());
             final Optional<Map<String, IDataRecreator>> cachedResult2 = cache.getCachedResult(hash2);
 
             // I think it is a problem regarding to identities and equality


### PR DESCRIPTION
* I introduced a change here to reduce a amount of work that needs
  to be done for requests in which the user only want to have some
  (not all) of the available outputs. In case the user don't ask for the
  parameter, the file is not read from the docker image.
  I hope that I can reduce the docker overhead for a process like
  deus, where we provide a combined output (so all the others
  don't need to read back in java)

* However, as this reduces the amount of data that is available in java,
  we need to include the set of requested parameters in the cache key
  (as some of the outputs may not be read in the previous run).